### PR TITLE
Fix /mappy slash commands and a 12.0 debug-lib crash

### DIFF
--- a/Libraries/MC2DebugLib/MC2DebugLib.lua
+++ b/Libraries/MC2DebugLib/MC2DebugLib.lua
@@ -23,20 +23,6 @@ function Addon.DebugLib:Initialize()
 	
 	self.Initialized = true
 	
-	-- ChatFrame_ConfigEventHandler was removed in 12.0. Guard the hook so the
-	-- missing global doesn't hard-error on the first debug/note/error message
-	-- (which would break /mappy help and all in-chat feedback).
-	if type(ChatFrame_ConfigEventHandler) == "function" then
-		hooksecurefunc(
-				"ChatFrame_ConfigEventHandler",
-				function (event)
-					if event == "UPDATE_CHAT_WINDOWS"
-					and not self.DebugFrame then
-						self:FindDebugFrame()
-					end
-				end)
-	end
-
 	self:FindDebugFrame()
 end
 

--- a/Libraries/MC2DebugLib/MC2DebugLib.lua
+++ b/Libraries/MC2DebugLib/MC2DebugLib.lua
@@ -23,15 +23,20 @@ function Addon.DebugLib:Initialize()
 	
 	self.Initialized = true
 	
-	hooksecurefunc(
-			"ChatFrame_ConfigEventHandler",
-			function (event)
-				if event == "UPDATE_CHAT_WINDOWS"
-				and not self.DebugFrame then
-					self:FindDebugFrame()
-				end
-			end)
-	
+	-- ChatFrame_ConfigEventHandler was removed in 12.0. Guard the hook so the
+	-- missing global doesn't hard-error on the first debug/note/error message
+	-- (which would break /mappy help and all in-chat feedback).
+	if type(ChatFrame_ConfigEventHandler) == "function" then
+		hooksecurefunc(
+				"ChatFrame_ConfigEventHandler",
+				function (event)
+					if event == "UPDATE_CHAT_WINDOWS"
+					and not self.DebugFrame then
+						self:FindDebugFrame()
+					end
+				end)
+	end
+
 	self:FindDebugFrame()
 end
 

--- a/Mappy.lua
+++ b/Mappy.lua
@@ -852,8 +852,7 @@ function Mappy:ExecuteCommand(pCommand)
 		-- "/mappy normal" works as well as "/mappy default" (key DEFAULT).
 		local vMatchedKey
 		for vKey, vDisplay in pairs(self.ProfileNameMap) do
-			if type(vDisplay) == "string" and vDisplay:lower() == vCommand
-			and gMappy_Settings.Profiles[vKey] then
+			if vDisplay:lower() == vCommand and gMappy_Settings.Profiles[vKey] then
 				vMatchedKey = vKey
 				break
 			end

--- a/Mappy.lua
+++ b/Mappy.lua
@@ -831,7 +831,9 @@ function Mappy:ExecuteCommand(pCommand)
 	local	vStartIndex, vEndIndex, vCommand, vParameter = string.find(pCommand, "(%w+) ?(.*)")
 	
 	if not vCommand then
-        Settings.OpenToCategory(self.name)
+        if Mappy.SettingsCategory then
+            Settings.OpenToCategory(Mappy.SettingsCategory:GetID())
+        end
 		return
 	end
 	
@@ -846,7 +848,23 @@ function Mappy:ExecuteCommand(pCommand)
 		gMappy_Settings.CurrentProfileName = vCommand
 		self:LoadProfile(gMappy_Settings.Profiles[vCommand])
 	else
-		self:ErrorMessage("Expected command")
+		-- Also accept a profile's display name (ProfileNameMap), so
+		-- "/mappy normal" works as well as "/mappy default" (key DEFAULT).
+		local vMatchedKey
+		for vKey, vDisplay in pairs(self.ProfileNameMap) do
+			if type(vDisplay) == "string" and vDisplay:lower() == vCommand
+			and gMappy_Settings.Profiles[vKey] then
+				vMatchedKey = vKey
+				break
+			end
+		end
+
+		if vMatchedKey then
+			gMappy_Settings.CurrentProfileName = vMatchedKey
+			self:LoadProfile(gMappy_Settings.Profiles[vMatchedKey])
+		else
+			self:ErrorMessage("Expected command")
+		end
 	end
 end
 
@@ -912,11 +930,11 @@ function Mappy:corner(pParameter)
 end
 
 function Mappy:cw(pParameter)
-	self:SetCCW(false)
+	self:SetCounterClockwise(false)
 end
 
 function Mappy:ccw(pParameter)
-	self:SetCCW(true)
+	self:SetCounterClockwise(true)
 end
 
 function Mappy:reset(pParameter)
@@ -2495,8 +2513,8 @@ function Mappy._OptionsPanel:Construct(pParent)
 
 	self.name = "Mappy Continued"
     local category, layout = Settings.RegisterCanvasLayoutCategory(self, self.name, self.name)
-    category.ID = self.name
     Settings.RegisterAddOnCategory(category)
+    Mappy.SettingsCategory = category
 
     --------------------------------
     -- title header
@@ -2758,7 +2776,7 @@ function Mappy._ButtonOptionsPanel:Construct(pParent)
 	self.name = "Buttons"
 	self.parent = "Mappy Continued"
 
-    local category = Settings.GetCategory(self.parent)
+    local category = Mappy.SettingsCategory
     local subcategory, layout = Settings.RegisterCanvasLayoutSubcategory(category, self, self.name, self.name)
     subcategory.ID = self.name
 
@@ -2913,7 +2931,7 @@ function Mappy._ProfilesPanel:Construct(pParent)
 	self.name = "Profiles"
 	self.parent = "Mappy Continued"
 
-    local category = Settings.GetCategory(self.parent)
+    local category = Mappy.SettingsCategory
     local subcategory, layout = Settings.RegisterCanvasLayoutSubcategory(category, self, self.name, self.name)
     subcategory.ID = self.name
 


### PR DESCRIPTION
Four independent, low-risk defects, all reproducible on current `master`
(v4.7.6) in WoW 12.0 retail. No behaviour change beyond the fixes; no new
dependencies.

1. **MC2DebugLib hard-errors on the first message.** `DebugLib:Initialize()`
   calls `hooksecurefunc("ChatFrame_ConfigEventHandler", ...)`; that global was
   removed in 12.0, so `hooksecurefunc` raises on the first
   `NoteMessage`/`ErrorMessage` — breaking `/mappy help`, all in-chat error
   feedback, and `/mappy gcompact`. Guarded with a `type(...) == "function"`
   check; `FindDebugFrame()` still runs.

2. **`/mappy cw` and `/mappy ccw` call an undefined `self:SetCCW()`.** The real
   method is `Mappy:SetCounterClockwise()` (already used correctly by the
   Counter-clockwise options checkbox). Repointed both slash handlers.

3. **`/mappy` (no args) opens the Settings root, not the Mappy panel.**
   `ExecuteCommand` called `Settings.OpenToCategory(self.name)` with
   `self == Mappy` (`Mappy.name` is nil); separately the panel did
   `category.ID = self.name`, clobbering the numeric category ID that
   `SettingsCategoryMixin` assigns, while `C_SettingsUtil.OpenSettingsPanel`
   requires a number — so no argument could ever resolve. Dropped the ID
   clobber, captured the registered category, and open it via
   `category:GetID()` (Blizzard's documented pattern). The Buttons/Profiles
   subpanels now register against that parent category object directly instead
   of `Settings.GetCategory("Mappy Continued")` (which only resolved because of
   the removed clobber).

4. **`/mappy <display name>` (e.g. `/mappy normal`) errors.** Profiles are keyed
   `DEFAULT`/`gather` but shown as `Normal`/`Gather` via `ProfileNameMap`;
   `ExecuteCommand` only matched profile keys. Added a `ProfileNameMap` reverse
   lookup before the error fallback — direct command and profile-key matches
   still take precedence, guarded on the profile existing.

Parse-checked with `luac5.1 -p`. Fixes 1–4 were also validated in-game on WoW
12.0 in a downstream fork.

Fixes #17

---

*Disclosure (full transparency): these defects were diagnosed and the fixes
implemented with the assistance of [Claude Code](https://claude.com/claude-code)
(Anthropic), then human-reviewed, parse-checked, and validated in-game on WoW
12.0 before submission. The commit carries a `Co-Authored-By` trailer for the
same reason.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
