### PR TITLE
Fix taint error comparing a secret frame width in IsButtonFrame

### DIFF
--- a/Mappy.lua
+++ b/Mappy.lua
@@ -1383,6 +1383,11 @@ function Mappy:IsButtonFrame(pFrame, pAnchoredTo)
 	local	vFrameWidth = pFrame:GetWidth()
 	local	vFrameHeight = pFrame:GetHeight()
 
+	-- a frame with a secret size can't be measured, so it can't be a minimap button
+	if issecretvalue and (issecretvalue(vFrameWidth) or issecretvalue(vFrameHeight)) then
+		return false
+	end
+
 	if self.IgnoreFrames[vFrameName]
 	or self.MinimapButtonsByFrame[pFrame]
 	or vFrameType == "Model"


### PR DESCRIPTION
Fixes #21.

`IsButtonFrame` compares `pFrame:GetWidth()` directly. On 12.x that value can come back as a **secret number** when the frame belongs to another addon, and comparing a secret while tainted throws:

```
Mappy.lua:1389: attempt to compare local 'vFrameWidth' (a secret number value, while execution tainted by 'Mappy')
```

`FindAddonButtons` walks every child of `MinimapCluster`, `MinimapBackdrop` and `Minimap`, then re-walks all of `UIParent` looking for frames anchored to them — so one secret-sized frame anywhere in the UI aborts button discovery for everything after it. In my case it was the anonymous Blizzard `AuraContainer` DBM creates in `DBM-Core/modules/AuraTracking.lua:442`.

This bails out before the comparison: a frame whose size is secret can't be measured, so it can't be classified as a minimap button. `IsButtonFrame` is the single choke point both `FindAddonButtons` call sites route through, so one guard covers the whole walk, and the `issecretvalue and` prefix keeps it a no-op on clients without the global.

The stacking math (`Mappy.lua:987`, `1017`) reads `GetHeight()` too, but only on buttons that already passed this check plus the explicitly named Blizzard/addon buttons, so I left it alone rather than scatter guards.

Tested on 12.0.7 with the crashing setup — buttons stack normally again, no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
